### PR TITLE
Fix typos and cleanup tests

### DIFF
--- a/cvxpy/constraints/power.py
+++ b/cvxpy/constraints/power.py
@@ -66,7 +66,7 @@ class PowCone3D(Cone):
         else:
             arg_shapes = [self.x.shape, self.y.shape, self.z.shape, self.alpha.shape]
         if any(arg_shapes[0] != s for s in arg_shapes[1:]):
-            msg = ("All arguments must have the same shapes. Provided arguments have"
+            msg = ("All arguments must have the same shapes. Provided arguments have "
                    "shapes %s" % str(arg_shapes))
             raise ValueError(msg)
         super(PowCone3D, self).__init__([self.x, self.y, self.z],

--- a/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
+++ b/cvxpy/reductions/solvers/conic_solvers/mosek_conif.py
@@ -533,7 +533,7 @@ class MOSEK(ConicSolver):
             raw_iis_sol = Solution(s.OPTIMAL, prob_val, prim_vars, dual_vars, attr)
             iis_sol = Dualize.invert(raw_iis_sol, inverse_data)
             # IIS is a map of constraint id to a value of
-            # dimension equal to the contraint dual variable.
+            # dimension equal to the constraint dual variable.
             # That value has non-zero entries iff the constraint
             # is in the IIS.
             attr[s.EXTRA_STATS] = {"IIS": iis_sol.dual_vars}

--- a/cvxpy/tests/test_atoms.py
+++ b/cvxpy/tests/test_atoms.py
@@ -48,7 +48,7 @@ class TestAtoms(BaseTest):
         self.C = Variable((3, 2), name='C')
 
     def test_add_expr_copy(self) -> None:
-        """Test the copy function for AddExpresion class.
+        """Test the copy function for AddExpression class.
         """
         atom = self.x + self.y
         copy = atom.copy()

--- a/cvxpy/tests/test_complex.py
+++ b/cvxpy/tests/test_complex.py
@@ -564,7 +564,6 @@ class TestComplex(BaseTest):
                      cp.log, cp.log1p, cp.logistic]:
             name = atom.__name__
             with self.assertRaises(Exception) as cm:
-                print(name)
                 atom(x)
             self.assertEqual(str(cm.exception), "Arguments to %s cannot be complex." % name)
 
@@ -572,7 +571,6 @@ class TestComplex(BaseTest):
         for atom in [cp.maximum, cp.kl_div]:
             name = atom.__name__
             with self.assertRaises(Exception) as cm:
-                print(name)
                 atom(x, x)
             self.assertEqual(str(cm.exception), "Arguments to %s cannot be complex." % name)
 

--- a/cvxpy/tests/test_conic_solvers.py
+++ b/cvxpy/tests/test_conic_solvers.py
@@ -372,7 +372,7 @@ class TestSCS(BaseTest):
 
             # Check problem data.
             data = prob.get_problem_data(solver=cp.SCS, solver_opts={"use_quad_obj": True})
-            # Quadratic objective and SOC contraints.
+            # Quadratic objective and SOC constraints.
             assert "P" in data[0]
             assert data[0]["dims"].soc
 

--- a/cvxpy/tests/test_expressions.py
+++ b/cvxpy/tests/test_expressions.py
@@ -611,7 +611,7 @@ class TestExpressions(BaseTest):
         self.assertEqual(A.is_psd(), True)
         self.assertEqual(A.is_nsd(), True)
 
-    # Test the AddExpresion class.
+    # Test the AddExpression class.
     def test_add_expression(self) -> None:
         # Vectors
         c = Constant([2, 2])


### PR DESCRIPTION
## Summary
- fix typo in Mosek solver comment
- fix typo in test_conic_solvers
- add missing space in `PowCone3D` error message
- correct "AddExpression" spelling in tests
- remove stray prints in `test_complex`

## Testing
- `ruff check .` *(fails: Found 38 errors)*
- `pytest cvxpy/tests/test_complex.py -k test_validation -q` *(fails: ImportError: numpy.core.multiarray failed to import)*

------
https://chatgpt.com/codex/tasks/task_e_68437cbb14648331bbc0dc2a0a237f73